### PR TITLE
get original video file

### DIFF
--- a/src/components/BynderInput.tsx
+++ b/src/components/BynderInput.tsx
@@ -28,14 +28,21 @@ const BynderInput = (props: Props) => {
     onChange(PatchEvent.from([unset()]));
   };
 
-  const getPreviewUrl = (asset: Record<string, any>) => {
+  const getPreviewUrl = (asset: Props['type']) => {
     switch (asset.type) {
       case 'VIDEO':
-        // if orignal asset is available (public videos only) use that if not fall back to the preview urls
-        return asset.files?.original?.url ?? asset.previewUrls[0];
+        return asset.previewUrls[0];
       default:
         return asset.files.webImage.url;
     }
+  };
+
+  const getVideoUrl = (asset: Props['type']) => {
+    if (asset.type === 'VIDEO') {
+      // if original asset is available (public videos only) use that if not fall back to the preview url
+      return asset.files?.original?.url ?? asset.previewUrls[0];
+    }
+    return null;
   };
 
   const getAspectRatio = (dimensions: {
@@ -44,12 +51,11 @@ const BynderInput = (props: Props) => {
   }): number => dimensions.height / dimensions.width;
 
   const openMediaSelector = () => {
-    const { onChange, type } = props;
-    const onSuccess = (assets: any[], additionalInfo: Record<string, any>) => {
-      console.log(additionalInfo);
+    const { onChange, type, value } = props;
+    const onSuccess = (assets: any[]) => {
       const asset = assets[0];
       const webImage = asset.files.webImage;
-      const previewUrl = getPreviewUrl(asset);
+
       const aspectRatio = getAspectRatio({
         width: webImage.width,
         height: webImage.height,
@@ -57,14 +63,16 @@ const BynderInput = (props: Props) => {
       onChange(
         PatchEvent.from([
           set({
+            _key: value?._key,
             _type: type.name,
             id: asset.id,
             name: asset.name,
             databaseId: asset.databaseId,
             type: asset.type,
-            previewUrl,
+            previewUrl: getPreviewUrl(asset),
             previewImg: webImage.url,
             datUrl: asset.files.transformBaseUrl?.url,
+            videoUrl: getVideoUrl(asset),
             description: asset.description,
             aspectRatio,
           }),
@@ -105,7 +113,8 @@ const BynderInput = (props: Props) => {
           sources={[{ src: value.previewUrl }]}
         />
       );
-    } else {
+    }
+    if (value.type === 'IMAGE') {
       preview = (
         <img
           alt="preview"
@@ -113,6 +122,7 @@ const BynderInput = (props: Props) => {
           style={{ maxWidth: '100%', height: 'auto' }}
         />
       );
+      // TODO: Add preview for document / audio types and empty state
     }
   }
 

--- a/src/components/BynderInput.tsx
+++ b/src/components/BynderInput.tsx
@@ -31,7 +31,8 @@ const BynderInput = (props: Props) => {
   const getPreviewUrl = (asset: Record<string, any>) => {
     switch (asset.type) {
       case 'VIDEO':
-        return asset.previewUrls[0];
+        // if orignal asset is available (public videos only) use that if not fall back to the preview urls
+        return asset.files?.original?.url ?? asset.previewUrls[0];
       default:
         return asset.files.webImage.url;
     }

--- a/src/schema/bynder.asset.ts
+++ b/src/schema/bynder.asset.ts
@@ -42,6 +42,10 @@ export default {
       type: 'number',
       name: 'aspectRatio',
     },
+    {
+      type: 'string',
+      name: 'videoUrl',
+    },
   ],
   inputComponent: BynderInput,
   diffComponent: BynderDiff,


### PR DESCRIPTION
Was unsure if this should live on the preview URL object key, or if we should add another field to the schema that is `videoFile` or similar? Could then only add to that if the original video file is available otherwise it would be `null`?

The crux is that `asset.previewUrls[0;` was supplying a compressed video file however in our case the compressed size is larger in filesize but smaller in dimensions, so can't ever see a use case for wanting to use it.

`asset.files.original.url` returns the original uploaded size, but is only available if someone has marked an asset as "public" - see attached screenshot. Realistically I'm not sure the video files that aren't public should even be shown here - however that is a limitation of bynders compact view not ours (couldn't see anything in the [docs](https://developer-docs.bynder.com/ui-components/) about limiting this) 


![image(1)](https://user-images.githubusercontent.com/8649366/135348253-e8787faf-c77a-4d27-a470-d89fcbe8a844.png)
 "